### PR TITLE
chore(pr-template): add default pull request template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,38 @@
+## Precedent work
+
+Does this have any preceding work?
+
+If there is any work that should precede the checking of this pull request, ie if this pull request is part of a multi-part task list, please list the work here, so the buddy checker knows when they should check this PR.
+
+## Describe the feature
+
+e.g. Describe your changes in detail, make sure that the work items are linked correctly.
+
+## Describe the feature change-set
+
+e.g. What features have been added, how should those features be tested.
+
+## Describe the context for the feature
+
+e.g. Why is it needed, what's the relevant context, issues, tasks for this Pull Request
+
+## Do the changes affect other parts of the application?
+
+Please describe any affects that this might have on other parts of the application.
+
+## How Has This Been Tested?
+
+Please describe in detail how you tested your changes using checkboxes, so the reviewer can check of what you have tested as they also test the bug fix.
+
+-   [ ] xxx
+-   [ ] yyy
+
+## Have you self reviewed your code?
+
+-   [ ] I have updated or added appropriate unit tests
+-   [ ] I have self reviewed my own code
+-   [ ] There are no errors or warnings in the compiler
+
+## Screenshots (if appropriate)
+
+---


### PR DESCRIPTION
## Describe the feature

Add new pull_request_template.md file

## Describe the feature change-set

## Describe the context for the feature

Currently, the PULL_REQUEST_TEMPLATE/ folder require manual actions from the developers: manually append a query parameter to the PR url.

This defeats the purpose of having automatic PR templates.

My assumption is if both the pull_request_template.md and the PULL_REQUEST_TEMPLATE/ exists, then github will use the former by default and we can still overwrite it using the `template=` query parameter.

## How Has This Been Tested?

N/A must be pushed to main for testing

## Have you self reviewed your code?

-   [ ] I have self reviewed my own code

## Screenshots (if appropriate)

---
